### PR TITLE
Fix macOS installer packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,30 @@ Both installers bundle **R Portable** with all required packages pre-installed (
 ### Quick Start
 
 1. Download the installer for your platform.
-2. **macOS**: Open the `.dmg`, drag to Applications. If Gatekeeper blocks it, right-click → Open → confirm.
+2. **macOS**: Open the `.dmg`, drag `DDM-UI.app` to Applications, then open it from Finder.
 3. **Windows**: Run the `.exe`, follow prompts. If SmartScreen warns, click "More info" → "Run anyway".
 4. Launch DDM-UI. R starts in the background automatically.
 5. Click any template on the Dashboard (e.g. Extinction), go to Simulation, click Run.
 6. Use playback to step through the network, or go to Results for charts and CSV export.
+
+### macOS Security Notice
+
+The macOS build is packaged with the full R simulation engine and is ad-hoc signed, but it is not yet notarized with Apple Developer ID. On first launch, macOS may show:
+
+> "Apple could not verify that DDM-UI is free of malware that may harm your Mac or compromise your privacy."
+
+or, in Spanish:
+
+> "Apple no pudo verificar que DDM-UI no contenga software malicioso que pudiera dañar tu Mac o poner tu privacidad en riesgo."
+
+This is a Gatekeeper verification warning for non-notarized apps. If you downloaded `DDM-UI.dmg` from this GitHub repository, open it with:
+
+1. Open the `.dmg` and drag `DDM-UI.app` to Applications.
+2. In Finder, open Applications.
+3. Control-click or right-click `DDM-UI.app`.
+4. Choose **Open**, then confirm **Open** again.
+
+If macOS still blocks it, go to **System Settings > Privacy & Security** and choose **Open Anyway** for DDM-UI.
 
 ---
 
@@ -395,7 +414,7 @@ University of Guadalajara — [CEIC Lab](http://www.ceic.cucba.udg.mx/Investigac
 
 ## Troubleshooting
 
-**macOS** — Gatekeeper block: right-click → Open → confirm (once).
+**macOS** — If Apple cannot verify DDM-UI, control-click or right-click the app in Applications, choose **Open**, then confirm. If needed, use **System Settings > Privacy & Security > Open Anyway**.
 **Windows** — SmartScreen warning: "More info" → "Run anyway".
 **Slow first launch** — R initializes on first run, wait a few seconds.
 **Can't run simulation** — need at least 2 NPEs, 1 connection, 1 trial type, 1 phase.

--- a/electron/package.json
+++ b/electron/package.json
@@ -9,9 +9,10 @@
     "start": "electron .",
     "build:frontend": "cd ../frontend && npm run build",
     "setup:r": "node scripts/setup-r-portable.js",
-    "dist:mac": "npm run build:frontend && electron-builder --mac",
-    "dist:win": "npm run build:frontend && electron-builder --win",
-    "dist": "npm run build:frontend && electron-builder --mac --win"
+    "setup:r:win": "node scripts/setup-r-portable-win.js",
+    "dist:mac": "npm run setup:r && npm run build:frontend && electron-builder --mac",
+    "dist:win": "npm run setup:r:win && npm run build:frontend && electron-builder --win",
+    "dist": "npm run setup:r && npm run setup:r:win && npm run build:frontend && electron-builder --mac --win"
   },
   "dependencies": {
     "electron-is-dev": "^2.0.0"
@@ -24,13 +25,13 @@
     "appId": "com.ddm-ui.app",
     "productName": "DDM-UI",
     "copyright": "Copyright © 2026 Miguel Ángel Aguayo Mendoza - University of Guadalajara",
+    "artifactName": "${productName}.${ext}",
     "directories": {
       "output": "release"
     },
+    "afterPack": "scripts/after-pack.js",
     "files": [
-      "main.js",
-      "preload.js",
-      "icon.ico"
+      "main.js"
     ],
     "extraResources": [
       {

--- a/electron/scripts/after-pack.js
+++ b/electron/scripts/after-pack.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function log(message) {
+  console.log(`[after-pack] ${message}`);
+}
+
+function run(command, args, options = {}) {
+  execFileSync(command, args, {
+    stdio: options.stdio || 'pipe',
+    ...options,
+  });
+}
+
+function chmodIfExists(filePath) {
+  if (!fs.existsSync(filePath)) return;
+  const stat = fs.statSync(filePath);
+  fs.chmodSync(filePath, stat.mode | 0o755);
+}
+
+function chmodFilesIn(dirPath) {
+  if (!fs.existsSync(dirPath)) return;
+
+  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+    const entryPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      chmodFilesIn(entryPath);
+    } else if (entry.isFile()) {
+      chmodIfExists(entryPath);
+    }
+  }
+}
+
+function stripExtendedAttributes(appPath) {
+  try {
+    run('/usr/bin/xattr', ['-cr', appPath]);
+    log('Removed extended attributes from app bundle');
+  } catch {
+    log('xattr cleanup skipped');
+  }
+}
+
+function signAdHoc(appPath) {
+  run('/usr/bin/codesign', ['--force', '--deep', '--sign', '-', appPath], {
+    stdio: 'inherit',
+  });
+  run('/usr/bin/codesign', ['--verify', '--deep', '--strict', '--verbose=2', appPath], {
+    stdio: 'inherit',
+  });
+  log('Applied ad-hoc macOS code signature');
+}
+
+module.exports = async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin' || process.platform !== 'darwin') {
+    return;
+  }
+
+  const macConfig = context.packager.config.mac || {};
+  if (macConfig.identity !== null) {
+    log('Skipping ad-hoc signing because a signing identity may be used');
+    return;
+  }
+
+  const appName = `${context.packager.appInfo.productFilename}.app`;
+  const appPath = path.join(context.appOutDir, appName);
+  if (!fs.existsSync(appPath)) {
+    throw new Error(`Expected app bundle not found: ${appPath}`);
+  }
+
+  const resourcesPath = path.join(appPath, 'Contents', 'Resources');
+  chmodFilesIn(path.join(resourcesPath, 'R-portable', 'bin'));
+  chmodIfExists(path.join(resourcesPath, 'R-portable', 'R'));
+  chmodIfExists(path.join(resourcesPath, 'R-portable', 'Rscript'));
+  chmodFilesIn(path.join(appPath, 'Contents', 'MacOS'));
+
+  stripExtendedAttributes(appPath);
+  signAdHoc(appPath);
+};

--- a/electron/scripts/setup-r-portable.js
+++ b/electron/scripts/setup-r-portable.js
@@ -30,6 +30,76 @@ function run(cmd) {
   return execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' }).trim();
 }
 
+function walk(dir, fn) {
+  if (!fs.existsSync(dir)) return;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      fn(entryPath, entry);
+      walk(entryPath, fn);
+    } else {
+      fn(entryPath, entry);
+    }
+  }
+}
+
+function removeDebugSymbols(dir) {
+  const dsyms = [];
+  walk(dir, (entryPath, entry) => {
+    if (entry.isDirectory() && entry.name.endsWith('.dSYM')) {
+      dsyms.push(entryPath);
+    }
+  });
+
+  for (const dsym of dsyms.sort((a, b) => b.length - a.length)) {
+    fs.rmSync(dsym, { recursive: true, force: true });
+  }
+
+  if (dsyms.length > 0) {
+    console.log(`  Removed ${dsyms.length} debug symbol directories`);
+  }
+}
+
+function normalizeMacNativeCode() {
+  if (process.platform !== 'darwin') return;
+
+  console.log('\nNormalizing macOS native libraries...');
+  spawnSync('/usr/bin/xattr', ['-cr', R_PORTABLE_DIR], { stdio: 'pipe' });
+
+  const nativeFiles = [];
+  walk(R_PORTABLE_DIR, (entryPath, entry) => {
+    if (!entry.isFile()) return;
+    if (entryPath.includes('.dSYM')) return;
+    if (entryPath.endsWith('.so') || entryPath.endsWith('.dylib')) {
+      nativeFiles.push(entryPath);
+    }
+  });
+
+  const executables = [
+    path.join(R_PORTABLE_DIR, 'R'),
+    path.join(R_PORTABLE_DIR, 'Rscript'),
+    path.join(R_PORTABLE_DIR, 'bin', 'R'),
+    path.join(R_PORTABLE_DIR, 'bin', 'Rscript'),
+    path.join(R_PORTABLE_DIR, 'bin', 'exec', 'R'),
+  ].filter(file => fs.existsSync(file));
+
+  for (const file of executables) {
+    fs.chmodSync(file, fs.statSync(file).mode | 0o755);
+    nativeFiles.push(file);
+  }
+
+  let signed = 0;
+  for (const file of nativeFiles) {
+    const result = spawnSync('/usr/bin/codesign', ['--force', '--sign', '-', file], {
+      stdio: 'pipe',
+    });
+    if (result.status === 0) signed++;
+  }
+
+  console.log(`  Ad-hoc signed ${signed} native files`);
+}
+
 function main() {
   console.log('═══════════════════════════════════════════════════════');
   console.log('  DDM-UI — R Portable Setup');
@@ -125,6 +195,9 @@ function main() {
     }
   }
   console.log(`  Copied ${copied} packages`);
+
+  removeDebugSymbols(portableLib);
+  normalizeMacNativeCode();
 
   // 6. Verify
   console.log('\nVerifying R-portable...');


### PR DESCRIPTION
## Summary
- Regenerate macOS R-portable before building the DMG so native R packages match the current R runtime.
- Strip macOS extended attributes, remove debug symbol bundles, and ad-hoc sign native R libraries/executables during setup.
- Add an afterPack hook that fixes executable permissions and ad-hoc signs the unpacked macOS app bundle when no Developer ID identity is configured.
- Produce a stable macOS artifact name: DDM-UI.dmg.

## Verification
- npm run dist:mac from a clean worktree based on origin/main.
- hdiutil verify release/DDM-UI.dmg.
- Mounted the DMG and verified DDM-UI.app with codesign --verify --deep --strict.
- Loaded plumber/jsonlite from the mounted app's bundled R-portable.
- Started the bundled Plumber API and confirmed /api/health responds.

Note: spctl still rejects the app because it is ad-hoc signed, not Developer ID signed/notarized. Users will still need right-click > Open unless a Developer ID certificate and notarization are added.